### PR TITLE
[PERF-4] Add Caffeine in-memory cache for recommendation results

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,6 +53,15 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/backend/src/main/java/com/lyricmind/LyricmindApplication.java
+++ b/backend/src/main/java/com/lyricmind/LyricmindApplication.java
@@ -2,8 +2,10 @@ package com.lyricmind;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class LyricmindApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/lyricmind/service/RecommendationService.java
+++ b/backend/src/main/java/com/lyricmind/service/RecommendationService.java
@@ -8,6 +8,7 @@ import com.lyricmind.repository.SongRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -31,7 +32,11 @@ public class RecommendationService {
      * 1. Vector search — retrieve semantically similar candidates
      * 2. LLM rerank   — select and rank the top {@code limit} songs by mood fit
      * 3. DB enrich    — single batch query to load full Song documents
+     *
+     * <p>Results are cached by (mood, limit) for 15 minutes. Cache is evicted
+     * when new songs are ingested via the bulk embedding endpoint.
      */
+    @Cacheable(value = "recommendations", key = "#mood.toLowerCase().trim() + ':' + #limit")
     public List<SongRecommendationResponse> recommendSongs(String mood, int limit) {
         long totalStart = System.currentTimeMillis();
         log.info("[START] Recommendations request — mood: '{}', limit: {}", mood, limit);

--- a/backend/src/main/java/com/lyricmind/service/SongEmbeddingService.java
+++ b/backend/src/main/java/com/lyricmind/service/SongEmbeddingService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,9 +81,11 @@ public class SongEmbeddingService {
 
     /**
      * CSV INGESTION ENDPOINT: File → Songs → Embeddings
-     * Orchestrates complete ingestion from CSV file path
+     * Orchestrates complete ingestion from CSV file path.
+     * Evicts the recommendations cache so newly ingested songs are immediately discoverable.
      */
     @Transactional
+    @CacheEvict(value = "recommendations", allEntries = true)
     public BulkSongResponse createEmbeddingFromBulkSong(BulkSongRequest request) {
         if (request == null || request.fileName() == null || request.fileName().trim().isEmpty()) {
             throw new IllegalArgumentException("Bulk request and filename cannot be null or empty");

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,3 +14,10 @@ spring.ai.openai.embedding.options.model=${SPRING_AI_OPENAI_EMBEDDING_MODEL:text
 spring.ai.openai.chat.options.model=${SPRING_AI_OPENAI_CHAT_MODEL:gpt-4o-mini}
 
 management.endpoints.web.exposure.include=health,info
+
+# --- Caching (Caffeine) ---
+# Caches recommendation results by (mood, limit) to avoid repeated OpenAI + DB calls.
+# TTL: 15 minutes | Max entries: 500 (covers a broad vocabulary of moods)
+# Cache is automatically evicted when new songs are ingested.
+spring.cache.type=caffeine
+spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=15m


### PR DESCRIPTION
## Summary
- Adds Caffeine in-memory cache to `recommendSongs()` with a 15-minute TTL
- Cache key: `mood.toLowerCase().trim() + ':' + limit`
- Cache eviction on new song ingestion ensures fresh results after `bulk-songs` import
- Zero cost for cache hits — no OpenAI, no MongoDB, no GPT calls

## Impact
Repeated identical queries (common moods like "happy", "chill", "sad") go from 2–6s → <1ms on second request.

## Configuration
```properties
spring.cache.type=caffeine
spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=15m
```
500 entries comfortably covers a broad vocabulary of moods. 15min TTL is appropriate since the song dataset changes only on explicit ingest calls.

## Test Plan
- [x] `./mvnw test` — 52 tests, 0 failures
- [ ] Manual: make same request twice, second should be faster (check logs for `[PERF]` times — second call should bypass all pipeline steps)
- [ ] Manual: ingest songs, confirm cache clears (subsequent recommendation reflects new songs)

Closes #5