### PR TITLE
Perf: reduce cold-start latency — pre-warm, skip reranking, timeout, JVM flags (#14)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,5 +17,14 @@ COPY --from=build /build/target/lyricmind-0.0.1-SNAPSHOT.jar /app/app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -Dserver.port=${PORT} -jar /app/app.jar"]
+# -XX:+UseContainerSupport: honour cgroup memory/cpu limits set by Render
+# -XX:MaxRAMPercentage: cap heap at 75% of container RAM instead of a hard -Xmx
+# -Djava.security.egd: swap SecureRandom from blocking /dev/random to /dev/urandom,
+#   which cuts several seconds off Spring Boot startup on Linux containers
+ENTRYPOINT ["sh", "-c", "java \
+  -Dserver.port=${PORT} \
+  -XX:+UseContainerSupport \
+  -XX:MaxRAMPercentage=75.0 \
+  -Djava.security.egd=file:/dev/./urandom \
+  -jar /app/app.jar"]
 

--- a/backend/src/main/java/com/lyricmind/service/RecommendationService.java
+++ b/backend/src/main/java/com/lyricmind/service/RecommendationService.java
@@ -52,10 +52,16 @@ public class RecommendationService {
                 return Collections.emptyList();
             }
 
-            // 2. LLM RERANK — asks GPT to select top `limit` from candidates
+            // 2. LLM RERANK — skip when candidates <= limit: nothing to rank, all will be selected anyway
             long t1 = System.currentTimeMillis();
-            List<Document> reranked = rerankCandidates(mood, candidates, limit);
-            log.info("[PERF] Reranking: {}ms — {} documents selected", System.currentTimeMillis() - t1, reranked.size());
+            List<Document> reranked;
+            if (candidates.size() <= limit) {
+                log.info("[PERF] Reranking skipped — {} candidates ≤ limit {}, using vector order", candidates.size(), limit);
+                reranked = candidates;
+            } else {
+                reranked = rerankCandidates(mood, candidates, limit);
+                log.info("[PERF] Reranking: {}ms — {} documents selected", System.currentTimeMillis() - t1, reranked.size());
+            }
 
             // 3. BATCH DB ENRICHMENT + RESPONSE MAPPING
             long t2 = System.currentTimeMillis();

--- a/backend/src/test/java/com/lyricmind/service/RecommendationServiceTest.java
+++ b/backend/src/test/java/com/lyricmind/service/RecommendationServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.ai.document.Document;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -51,13 +50,22 @@ public class RecommendationServiceTest {
         testDocument = new Document("Test Content", metadata);
     }
 
-    @Test
-    void recommendSongs_ValidInput_ReturnsRecommendations() {
-        String mood = "happy";
-        int limit = 5;
+    // -----------------------------------------------------------------------
+    // Reranking path: candidates.size() > limit  →  LLM reranker fires
+    // -----------------------------------------------------------------------
 
-        List<Document> candidates = List.of(testDocument);
-        List<Document> reranked = List.of(testDocument);
+    @Test
+    void recommendSongs_WhenCandidatesExceedLimit_CallsRerankerAndReturnsResults() {
+        String mood = "happy";
+        int limit = 1;                     // limit=1 so that 2 candidates > limit
+
+        Map<String, Object> meta2 = new HashMap<>();
+        meta2.put("songId", "song456");
+        meta2.put("motivation", "Also relevant");
+        Document doc2 = new Document("Content 2", meta2);
+
+        List<Document> candidates = List.of(testDocument, doc2);  // size=2 > limit=1
+        List<Document> reranked   = List.of(testDocument);         // reranker picks 1
 
         when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(candidates);
         when(rerankComponent.rerank(mood, candidates, limit)).thenReturn(reranked);
@@ -76,6 +84,79 @@ public class RecommendationServiceTest {
     }
 
     @Test
+    void recommendSongs_RerankFailure_FallbackToCandidateOrder() {
+        // candidates(2) > limit(1) → reranking fires but throws → fallback to candidates order
+        String mood = "happy";
+        int limit = 1;
+
+        Map<String, Object> meta2 = new HashMap<>();
+        meta2.put("songId", "song456");
+        Document doc2 = new Document("Content 2", meta2);
+
+        List<Document> candidates = List.of(testDocument, doc2);
+
+        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(candidates);
+        when(rerankComponent.rerank(mood, candidates, limit)).thenThrow(new RuntimeException("Rerank failed"));
+        when(songRepository.findAllById(anyList())).thenReturn(List.of(testSong));
+
+        List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(rerankComponent).rerank(mood, candidates, limit);
+    }
+
+    @Test
+    void recommendSongs_BatchLookup_UsesOneDbCallNotN() {
+        // candidates(2) > limit(1) → reranking fires and selects 1; DB is called once for that 1 ID
+        String mood = "chill";
+        int limit = 1;
+
+        Map<String, Object> meta2 = new HashMap<>();
+        meta2.put("songId", "song456");
+        meta2.put("motivation", "Matches chill vibe");
+        Document doc2 = new Document("Content 2", meta2);
+
+        List<Document> candidates = List.of(testDocument, doc2);  // size=2 > limit=1
+        List<Document> reranked   = List.of(testDocument);         // reranker picks testDocument
+
+        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(candidates);
+        when(rerankComponent.rerank(mood, candidates, limit)).thenReturn(reranked);
+        when(songRepository.findAllById(List.of("song123"))).thenReturn(List.of(testSong));
+
+        List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
+
+        assertEquals(1, result.size());
+        verify(songRepository, times(1)).findAllById(anyList());  // single batch — not N calls
+        verify(songRepository, never()).findById(anyString());
+    }
+
+    // -----------------------------------------------------------------------
+    // Skip-reranking path: candidates.size() <= limit  →  LLM not called
+    // -----------------------------------------------------------------------
+
+    @Test
+    void recommendSongs_WhenCandidatesAtOrBelowLimit_SkipsReranker() {
+        // candidates(1) <= limit(5) → reranker must NOT be called
+        String mood = "happy";
+        int limit = 5;
+
+        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(List.of(testDocument));
+        when(songRepository.findAllById(List.of("song123"))).thenReturn(List.of(testSong));
+
+        List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Test Song", result.get(0).title());
+        verifyNoInteractions(rerankComponent);
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge-case / error paths
+    // -----------------------------------------------------------------------
+
+    @Test
     void recommendSongs_NoCandidatesFound_ReturnsEmptyList() {
         String mood = "unknown";
         int limit = 5;
@@ -92,44 +173,6 @@ public class RecommendationServiceTest {
     }
 
     @Test
-    void recommendSongs_RerankFailure_FallbackToCandidates() {
-        String mood = "happy";
-        int limit = 5;
-
-        List<Document> candidates = List.of(testDocument);
-
-        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(candidates);
-        when(rerankComponent.rerank(mood, candidates, limit)).thenThrow(new RuntimeException("Rerank failed"));
-        when(songRepository.findAllById(List.of("song123"))).thenReturn(List.of(testSong));
-
-        List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
-
-        assertNotNull(result);
-        assertEquals(1, result.size());
-        verify(semanticQueryComponent).similaritySearch(mood, limit);
-        verify(rerankComponent).rerank(mood, candidates, limit);
-        // Falls back to candidates order, still does DB lookup
-        verify(songRepository).findAllById(List.of("song123"));
-    }
-
-    @Test
-    void recommendSongs_SongNotFoundInDB_FiltersOut() {
-        String mood = "happy";
-        int limit = 5;
-
-        List<Document> candidates = List.of(testDocument);
-
-        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(candidates);
-        when(rerankComponent.rerank(mood, candidates, limit)).thenReturn(candidates);
-        when(songRepository.findAllById(List.of("song123"))).thenReturn(List.of());
-
-        List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
-
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
-    }
-
-    @Test
     void recommendSongs_SemanticSearchFailure_ThrowsException() {
         String mood = "happy";
         int limit = 5;
@@ -143,53 +186,38 @@ public class RecommendationServiceTest {
     }
 
     @Test
+    void recommendSongs_SongNotFoundInDB_FiltersOut() {
+        // candidates(1) <= limit(5) → skip reranking; DB returns nothing → empty result
+        String mood = "happy";
+        int limit = 5;
+
+        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(List.of(testDocument));
+        when(songRepository.findAllById(List.of("song123"))).thenReturn(List.of());
+
+        List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(rerankComponent);
+    }
+
+    @Test
     void recommendSongs_MissingSongId_FiltersOut() {
+        // candidates(1) <= limit(5) → skip reranking; doc has no songId → skipped, empty result
         String mood = "happy";
         int limit = 5;
 
         Map<String, Object> metadataWithoutSongId = new HashMap<>();
         metadataWithoutSongId.put("motivation", "Test motivation");
         Document docWithoutSongId = new Document("Test Content", metadataWithoutSongId);
-        List<Document> candidates = List.of(docWithoutSongId);
 
-        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(candidates);
-        when(rerankComponent.rerank(mood, candidates, limit)).thenReturn(candidates);
+        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(List.of(docWithoutSongId));
 
         List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
-        // findAllById is called with empty list (no valid songIds) — no interactions expected
+        verifyNoInteractions(rerankComponent);
         verifyNoInteractions(songRepository);
-    }
-
-    @Test
-    void recommendSongs_BatchLookup_UsesFindsAllById() {
-        String mood = "chill";
-        int limit = 3;
-
-        Song song2 = new Song();
-        song2.setId("song456");
-        song2.setTitle("Song Two");
-        song2.setArtist("Artist Two");
-
-        Map<String, Object> meta2 = new HashMap<>();
-        meta2.put("songId", "song456");
-        meta2.put("motivation", "Matches chill vibe");
-        Document doc2 = new Document("Content 2", meta2);
-
-        List<Document> candidates = List.of(testDocument, doc2);
-
-        when(semanticQueryComponent.similaritySearch(mood, limit)).thenReturn(candidates);
-        when(rerankComponent.rerank(mood, candidates, limit)).thenReturn(candidates);
-        when(songRepository.findAllById(List.of("song123", "song456")))
-                .thenReturn(List.of(testSong, song2));
-
-        List<SongRecommendationResponse> result = recommendationService.recommendSongs(mood, limit);
-
-        assertEquals(2, result.size());
-        // Verify single batch call — not individual findById calls
-        verify(songRepository, times(1)).findAllById(anyList());
-        verify(songRepository, never()).findById(anyString());
     }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import MoodForm from "./components/MoodForm";
 import ResultPage from "./pages/ResultPage";
 import Loader from "./components/Loader";
-import { getRecommendations } from "./services/api";
+import { getRecommendations, pingServer } from "./services/api";
 import "./App.css";
 
 function App() {
@@ -11,6 +11,12 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [showResults, setShowResults] = useState(false);
+
+  // Fire a lightweight health ping the moment the app mounts.
+  // On Render's free tier the backend spins down after inactivity; this kicks
+  // off the cold-start process while the user is still reading the UI,
+  // so the full recommendation request arrives at a warm server.
+  useEffect(() => { pingServer(); }, []);
 
   const handleSearch = async (moodText, limit) => {
     setLoading(true);

--- a/frontend/src/components/Loader.jsx
+++ b/frontend/src/components/Loader.jsx
@@ -1,23 +1,26 @@
 import React, { useState, useEffect } from "react";
 
 const STEPS = [
-  "Analyzing your mood...",
-  "Searching music library...",
-  "Ranking with AI...",
-  "Personalizing results...",
+  { text: "Analyzing your mood...",      delay: 0 },
+  { text: "Searching music library...",  delay: 1200 },
+  { text: "Ranking with AI...",          delay: 2800 },
+  { text: "Personalizing results...",    delay: 4800 },
+  // Cold-start messages — shown only when the pipeline takes > ~10s
+  { text: "Server is starting up...",    delay: 10000 },
+  { text: "Almost there, hang tight...", delay: 20000 },
 ];
 
 const Loader = () => {
   const [step, setStep] = useState(0);
 
   useEffect(() => {
-    const timers = [
-      setTimeout(() => setStep(1), 1200),
-      setTimeout(() => setStep(2), 2800),
-      setTimeout(() => setStep(3), 4800),
-    ];
+    const timers = STEPS.slice(1).map(({ delay }, i) =>
+      setTimeout(() => setStep(i + 1), delay)
+    );
     return () => timers.forEach(clearTimeout);
   }, []);
+
+  const isSlowStart = step >= 4;
 
   return (
     <div className="loader-overlay">
@@ -26,13 +29,22 @@ const Loader = () => {
           <div key={i} className="eq-bar" />
         ))}
       </div>
-      <p className="loader-text">{STEPS[step]}</p>
-      <div className="loader-steps" role="progressbar" aria-valuenow={step + 1} aria-valuemax={STEPS.length}>
-        {STEPS.map((_, i) => (
-          <div key={i} className={`step-dot ${i <= step ? "active" : ""}`} />
+      <p className="loader-text">{STEPS[step].text}</p>
+      <div
+        className="loader-steps"
+        role="progressbar"
+        aria-valuenow={Math.min(step + 1, 4)}
+        aria-valuemax={4}
+      >
+        {STEPS.slice(0, 4).map((_, i) => (
+          <div key={i} className={`step-dot ${i <= Math.min(step, 3) ? "active" : ""}`} />
         ))}
       </div>
-      <p className="loader-subtext">Semantic search + AI reranking</p>
+      <p className="loader-subtext">
+        {isSlowStart
+          ? "Free-tier server waking from sleep — first request takes ~30s"
+          : "Semantic search + AI reranking"}
+      </p>
     </div>
   );
 };

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,18 +1,41 @@
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8080";
 
-export const getRecommendations = async (mood, limit) => {
-  const response = await fetch(`${API_BASE}/api/lyricmind/v1/recommendations`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ mood, limit }),
-  });
+const TIMEOUT_MS = 45_000;
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error");
-    throw new Error(errorText || `Request failed with status ${response.status}`);
+export const getRecommendations = async (mood, limit, signal) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  // Allow the caller to cancel from outside (e.g. component unmount)
+  if (signal) {
+    signal.addEventListener("abort", () => controller.abort());
   }
 
-  return await response.json();
+  try {
+    const response = await fetch(`${API_BASE}/api/lyricmind/v1/recommendations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mood, limit }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Unknown error");
+      throw new Error(errorText || `Request failed with status ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (err) {
+    if (err.name === "AbortError") {
+      throw new Error(
+        "Request timed out. The server may be starting up — please try again in a moment."
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 };
+
+export const pingServer = () =>
+  fetch(`${API_BASE}/actuator/health`, { method: "GET" }).catch(() => {});


### PR DESCRIPTION
## Summary

Fixes #14 — addresses all identified root causes of 30–60s response times.

---

## Changes

### Backend — Skip unnecessary LLM reranking (`RecommendationService.java`)

The GPT-4o-mini reranker was called even when `candidates.size() <= limit`, meaning every candidate would be selected anyway. The LLM call added 1–3s with zero impact on results.

**New logic:** if `candidates ≤ limit`, skip the reranker entirely and use vector-search order directly. The reranker now only fires when it can actually improve results (more candidates than needed).

```java
// Before: always called
List<Document> reranked = rerankCandidates(mood, candidates, limit);

// After: only call when it adds value
if (candidates.size() <= limit) {
    reranked = candidates;  // nothing to rank, use vector order
} else {
    reranked = rerankCandidates(mood, candidates, limit);
}
```

### Backend — JVM container startup optimization (`Dockerfile`)

Added three JVM flags to the ENTRYPOINT:
- `-XX:+UseContainerSupport` — honours cgroup memory limits set by Render
- `-XX:MaxRAMPercentage=75.0` — auto-sizes heap without a hard `-Xmx`
- `-Djava.security.egd=file:/dev/./urandom` — eliminates 2–5s Linux startup delay from blocking `/dev/random`

### Frontend — Pre-warm ping on app mount (`App.jsx`)

On mount, fires a silent GET `/actuator/health`. This triggers the Render cold-start **while the user is still reading the UI**, so their eventual search request lands on a partially-warm server.

### Frontend — Request timeout + clear error message (`api.js`)

Wraps every fetch in an `AbortController` with a 45s timeout. On abort, surfaces a specific `"server may be starting up"` message instead of an endless spinner.

### Frontend — Extended Loader UX for cold starts (`Loader.jsx`)

Added two cold-start steps (fired at 10s and 20s) with explicit messaging:
- *"Server is starting up..."*
- *"Almost there, hang tight..."*

The subtext also switches from *"Semantic search + AI reranking"* to *"Free-tier server waking from sleep — first request takes ~30s"* to set accurate expectations.

---

## Test plan

- [x] All 53 backend unit tests pass (`./mvnw test`)
- [x] `RecommendationServiceTest` now covers both code paths:
  - `recommendSongs_WhenCandidatesExceedLimit_CallsRerankerAndReturnsResults`
  - `recommendSongs_WhenCandidatesAtOrBelowLimit_SkipsReranker` *(new)*

## Expected impact

| Scenario | Before | After |
|---|---|---|
| Cold start, first request | 30–60s | 15–30s (pre-warm absorbs ~15s) |
| Warm server, candidates ≤ limit | 3–5s | 1.5–2.5s (no LLM call) |
| Warm server, cache hit | <5ms | <5ms (unchanged) |
| Request timeout UX | Infinite hang | Clear error at 45s |