### PR TITLE
docs: sync README and DEVELOPER_GUIDE with PR #15 and #16 changes (#17)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -165,7 +165,7 @@ cd backend
 ./mvnw test
 ```
 
-Expected: 52 tests, 0 failures.
+Expected: 53 tests, 0 failures.
 
 ---
 
@@ -215,15 +215,24 @@ Cache is automatically evicted on `POST /api/lyricmind/v1/embeddings/bulk-songs`
 
 ### Reranking
 
-The reranking prompt asks GPT to select exactly `limit` songs from `limit + min(limit, 5)` candidates. This means:
+The vector search fetches `limit + min(limit, 5)` candidates (topK) so the reranker has a selection pool larger than the final result set.
+
+**Skip optimisation:** When the similarity threshold filters so aggressively that `candidates.size() ≤ limit`, there is nothing to rank — every candidate will be returned regardless of order. In this case `RecommendationService` skips the GPT-4o-mini call entirely and uses the vector-search order directly, saving 1–3s.
+
+When reranking does run, the prompt asks GPT to **select** exactly `limit` songs (not rank all M). This means:
 - `limit=5` → GPT selects 5 from 10 candidates
 - `limit=10` → GPT selects 10 from 15 candidates
 
-GPT output token count is O(limit), not O(topK) — this is intentional and important for latency.
+GPT output token count is O(limit), not O(topK) — intentional for latency.
+
+If reranking throws an exception, `RecommendationService` catches it and falls back to the vector-search order silently (the user still gets results).
 
 ### Similarity Threshold
 
-The vector search similarity threshold is `0.6` (configurable in `SemanticQueryComponent`). Lower values return more candidates but with weaker semantic match. Raise to `0.7–0.8` if you're getting irrelevant results.
+The vector search similarity threshold is `0.5` (configurable in `SemanticQueryComponent`). This value was deliberately chosen lower than a typical text-search threshold because mood queries and song lyrics live in different semantic registers — abstract mood descriptions ("heartbreak and missing someone") vs. colloquial / slang-heavy lyrics. A threshold of 0.6 or higher causes valid matches to be filtered out.
+
+- **Lower** (e.g. `0.4`) if users are frequently seeing "No songs found" for reasonable mood descriptions.
+- **Raise** (e.g. `0.65`) only if you expand the dataset significantly and start seeing irrelevant results slipping through.
 
 ---
 
@@ -266,7 +275,7 @@ Skipping tests during image build (`-DskipTests`) is intentional — tests requi
    - `SPRING_AI_OPENAI_API_KEY` — **required**
    - `SPRING_DATA_MONGODB_DATABASE` — optional, default `lyricmind`
 
-> **Free vs Paid tier**: Render's free tier spins down after 15 minutes of inactivity, causing 30–60s cold starts. For production use or demos, upgrade to the paid Starter plan ($7/month) for always-on instances.
+> **Free vs Paid tier**: Render's free tier spins down after 15 minutes of inactivity. Container restart + JVM startup + Spring context initialisation takes 30–45s. The frontend mitigates this automatically: `App.jsx` fires a silent `GET /actuator/health` ping the moment the page loads, so the cold-start process begins while the user is still reading the UI. A clear *"Server is starting up..."* message appears in the loader after 10s, and all requests time out with a user-friendly error after 45s. For production use or demos, upgrade to the paid Starter plan ($7/month) for always-on instances.
 
 > **Region alignment**: For lowest latency, deploy the Render service in the same region as your MongoDB Atlas cluster (e.g., both in `us-east-1`).
 
@@ -295,4 +304,5 @@ Set `VITE_API_URL` to your Render backend URL in the hosting platform's environm
 | Vector search returns 0 results | Index not created, or no songs ingested | Create the Atlas vector index (§3.3), then run bulk ingest (§6) |
 | `Invalid JSON response from AI model` | GPT returned markdown-wrapped JSON | Already handled by `cleanJsonResponse()` — if still failing, check OpenAI API status |
 | Recommendations are stale after ingest | Cache not evicted | Cache is evicted automatically by `@CacheEvict` on the bulk-songs endpoint |
-| Cold start delay on first request | Render free tier | Upgrade to Render Starter plan, or send a warm-up ping before demo |
+| Cold start delay on first request | Render free tier (30–45s container + JVM startup) | The frontend automatically pings `/actuator/health` on page load to start warming the server. For guaranteed low latency, upgrade to the Render Starter plan ($7/month). |
+| Request hangs for >45s, then shows timeout error | Server was cold; pre-warm ping didn't fully absorb the startup time | Expected behaviour — the loader shows "Server is starting up..." at 10s. Retry the search once the server is warm. |

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Full architecture details: [DEVELOPER_GUIDE.md](./DEVELOPER_GUIDE.md)
 1. `POST /api/lyricmind/v1/recommendations` with `mood` and `limit`
 2. Cache check — if `(mood, limit)` seen in last 15 min, return instantly
 3. `SemanticQueryComponent` embeds the mood query and queries the HNSW vector index  
-   (`topK = limit + min(limit, 5)`, similarity threshold `0.6`)
+   (`topK = limit + min(limit, 5)`, similarity threshold `0.5`)
 4. `RerankComponent` asks GPT-4o-mini to **select the top `limit`** songs from candidates  
-   (output is O(limit) tokens, not O(topK) — intentionally smaller for latency)
+   — skipped entirely when `candidates ≤ limit` (nothing to rank, saves 1–3s)  
+   — when it runs, output is O(limit) tokens, not O(topK), for lower latency
 5. `RecommendationService` loads full song metadata with a single `findAllById()` batch call
 6. Returns `SongRecommendationResponse[]`
 
@@ -153,12 +154,14 @@ docker run --rm -p 8080:8080 \
 | Scenario | Latency |
 |---|---|
 | Cache hit (repeat query) | < 5ms |
-| limit=1, warm | ~1s |
-| limit=5, warm | ~1.5–2s |
-| limit=10, warm | ~2.5–3.5s |
-| Cold start (Render free tier) | +8–15s first request only |
+| limit=1–5, warm, reranking runs | ~1.5–2.5s |
+| limit=10, warm, reranking runs | ~2.5–3.5s |
+| Warm, vector search returns ≤ limit results | ~0.5–1s (reranking skipped) |
+| Cold start (Render free tier) | +30–45s container + JVM startup |
 
-Primary latency driver is GPT-4o-mini reranking, which scales O(limit) — not O(topK) — due to the "select top N" prompt design. See [DEVELOPER_GUIDE.md § Performance Configuration](./DEVELOPER_GUIDE.md#7-performance-configuration).
+**Render free tier note:** The frontend fires a silent `GET /actuator/health` ping the moment the page loads, triggering the cold-start process in the background. By the time most users finish reading the UI and submit a search, 10–20s of startup has already elapsed, reducing perceived wait to ~15–30s. On the first request after a cold start, the loader will display a *"Server is starting up..."* message after 10 seconds and time out cleanly after 45 seconds.
+
+Primary latency driver is GPT-4o-mini reranking, which scales O(limit) — not O(topK) — due to the "select top N" prompt design. Reranking is skipped entirely when the similarity filter returns fewer candidates than the requested limit. See [DEVELOPER_GUIDE.md § Performance Configuration](./DEVELOPER_GUIDE.md#7-performance-configuration).
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #17 — brings both documentation files up to date with the behavioural changes introduced in PR #15 (suggestion alignment) and PR #16 (cold-start latency). No code changes.

---

## Changes

### README.md

**Backend Flow**
- Step 3: similarity threshold `0.6` → `0.5`
- Step 4: document that reranking is now **conditional** — skipped when `candidates ≤ limit`, saving 1–3s

**Performance Characteristics table**
- Cold-start corrected from `+8–15s` (significantly underestimated) → `+30–45s`
- Added row: *"Warm, vector search returns ≤ limit results → ~0.5–1s (reranking skipped)"*
- Corrected warm-server latency rows to reflect post-optimisation numbers

**Render free tier note** (new paragraph)
- Explains the automatic pre-warm health ping fired on page load
- Describes the cold-start loader messages (10s, 20s) and 45s timeout behaviour

---

### DEVELOPER_GUIDE.md

**§5 Run Tests**
- `52 tests` → `53 tests` (one new test added for the skip-rerank path)

**§7 Reranking** (expanded)
- Documents the skip-rerank optimisation (`candidates ≤ limit → LLM call skipped`)
- Documents the exception-fallback behaviour (rerank fails → vector order used silently)

**§7 Similarity Threshold** (rewritten)
- `0.6` → `0.5`
- Explains *why* 0.5 was chosen: cross-domain semantic gap between abstract mood descriptions and slang-heavy lyrics makes 0.6 too aggressive
- Replaces "Raise to 0.7–0.8 if irrelevant results" with directional tuning guidance for both directions

**§9 Render Free Tier note** (expanded)
- Replaces vague "causing 30–60s cold starts" with an accurate breakdown
- Explains automatic frontend pre-warm, loader messages, and 45s timeout

**§10 Troubleshooting** (two rows updated)
- Updated cold-start row: accurate timing, mention automatic pre-warm
- Added new row: timeout-error → expected behaviour on cold start, retry once warm

## Test plan

- [x] All links in README reference sections that still exist
- [x] Numbers in both files match the running code (`SemanticQueryComponent.java`, `RecommendationService.java`, `Loader.jsx`, `api.js`)
- [x] No code was changed — documentation only